### PR TITLE
Bash utils

### DIFF
--- a/src/games/miniGameTemplate/miniGameClass.js
+++ b/src/games/miniGameTemplate/miniGameClass.js
@@ -2,7 +2,7 @@ import { MiniGame } from '../../miniGameBase.js';
 
 export class YourMiniGame extends MiniGame {
   constructor() {
-    super({ name: 'YourMiniGame Name', instructions: 'Do the thing!' });
+    super({ name: 'YourMiniGame', instructions: 'Do the thing!' });
 
     this.instructions.inputs = {
       usesMouseClick: false,

--- a/utils.sh
+++ b/utils.sh
@@ -3,7 +3,7 @@
 ####################################################################
 
 # Before using
-# * Give utils.sh execution rights: chown +x ./utils.sh
+# * Give utils.sh execution rights: chmod +x ./utils.sh
 
 # Usage
 # * Create new game

--- a/utils.sh
+++ b/utils.sh
@@ -129,6 +129,9 @@ if declare -f "util_$1" >/dev/null 2>&1; then
   shift
   "$func" "$@"
 else
-  echo "Function $1 not recognized" >&2
+  printf "\nCommand '%s' not recognized" $1
+  printf "\n\n Valid commands are:"
+  printf "\n  $ ./utils.sh new [gameName]"
+  printf "\n  $ ./utils.sh update_templates\n\n"
   exit 1
 fi

--- a/utils.sh
+++ b/utils.sh
@@ -77,7 +77,7 @@ util_new() {
   # with user provided name
   local new_sketch_file="$new_dir_path/sketch.js"
   local new_class_file="$new_dir_path/miniGameClass.js"
-  command sed -i "" "s/YourMiniGame/$class_name/" "$new_sketch_file"
+  command sed -i "" "s/YourMiniGame as UserMiniGame/$class_name as UserMiniGame/" "$new_sketch_file"
   command sed -i "" "s/YourMiniGame/$class_name/" "$new_class_file"
 }
 

--- a/utils.sh
+++ b/utils.sh
@@ -9,7 +9,7 @@
 # * Create new game
 #   * with default name: ./utils.sh new
 #   * with custom name:  ./utils.sh new dadBall
-# * Update mini game sketch templates (NOT IMPLEMENTED)
+# * Update mini game sketch templates
 #   * ./utils.sh update_templates
 
 ####################################################################
@@ -25,10 +25,6 @@
 # Details
 # * name defaults to "YourMiniGame" if none provided
 # * fails if dir with same name already exists
-#
-# Usage (run in repo's root dir)
-# * Create with default name: ./utils.sh new
-# * Create with custom name: ./utils.sh new dadBall
 util_new() {
   local game_name=$1
   local dir_name
@@ -86,9 +82,43 @@ util_new() {
 }
 
 
+# Function for finding class name in a `miniGameClass.js` file
+# 
+# Details
+# * Looks for line exporting/declaring a class that extends MiniGame
+# * echos name of class if found
+find_class_name() {
+  local re="^export class ([A-Za-z]+) extends MiniGame \{$"
+  while read -r line ; do 
+    if [[ "$line" =~ $re ]]; then 
+      echo "${BASH_REMATCH[1]}"
+      exit 0
+    fi
+  done < "$1"
+}
+
+# Function for finding class name in a `miniGameClass.js` file
+#
+# Performs
+# * Copies sketch template: `./src/games/miniGameTemplate/sketch.js`
+# * Overwrites game sketches with template: `./src/games/*/sketch.js`
+# * Corrects class import in newly updated `./src/games/*/sketch.js`
 util_update_templates() {
-  echo "Not implemented yet"
-  exit 1
+  local templateSketch="./src/games/miniGameTemplate/sketch.js"
+  
+  for dir in ./src/games/*/
+  do
+    dir=${dir%*/} 
+    local dirSketchFile=$dir"/sketch.js"
+    local dirClassFile=$dir"/miniGameClass.js"
+    local class_name
+
+    if [ "$dirSketchFile" != "$templateSketch" ]; then
+      class_name="$(find_class_name "$dirClassFile")"
+      command cp "$templateSketch" "$dirSketchFile"
+      command sed -i "" "s/YourMiniGame as UserMiniGame/$class_name as UserMiniGame/" "$dirSketchFile"
+    fi
+  done
 }
 
 

--- a/utils.sh
+++ b/utils.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+####################################################################
+
+# Before using
+# * Give utils.sh execution rights: chown +x ./utils.sh
+
+# Usage
+# * Create new game
+#   * with default name: ./utils.sh new
+#   * with custom name:  ./utils.sh new dadBall
+# * Update mini game sketch templates (NOT IMPLEMENTED)
+#   * ./utils.sh update_templates
+
+####################################################################
+
+
+# Function for starting a new mini game.
+#
+# Performs
+# * Copying miniGameTemplate directory
+# * Renaming of newly copied dir
+# * Renaming of class name (in sketch & class)
+#
+# Details
+# * name defaults to "YourMiniGame" if none provided
+# * fails if dir with same name already exists
+#
+# Usage (run in repo's root dir)
+# * Create with default name: ./utils.sh new
+# * Create with custom name: ./utils.sh new dadBall
+util_new() {
+  local game_name=$1
+  local dir_name
+  local class_name
+
+  # Check if name passed. 
+  # If not, set defaults and alert user
+  # name has been defaulted and should be updated.
+  if [ -z "$game_name" ]; then
+    game_name="YourMiniGame"
+    dir_name="yourMiniGame"
+    class_name="YourMiniGame"
+    printf "\nNo name provided. Name defaulting to '%s'." $game_name
+    printf "\n\nBe sure to update to your game's name:"
+    printf "\n  * Update dir name"
+    printf "\n  * Update class name in sketch.js and miniGameClass.js"
+    printf "\n  * Update class name in miniGameClass.js\n\n"
+  else
+    # With user provided name
+    # Create class name (upper case first letter)
+    # Create dir name (lower case first letter)
+
+    local first_letter="${game_name:0:1}"
+    local remaining_name="${game_name:1:${#game_name}}"
+
+    local lower_first_letter
+    local upper_first_letter
+    upper_first_letter=$(echo $first_letter | tr '[:lower:]' '[:upper:]')
+    lower_first_letter=$(echo $first_letter | tr '[:upper:]' '[:lower:]')
+    
+    dir_name="$lower_first_letter$remaining_name"
+    class_name="$upper_first_letter$remaining_name"
+  fi
+
+  # Create full path to new dir and exit if dir already exists
+  local new_dir_path="./src/games/$dir_name"
+  if [ -d "$new_dir_path" ]; then
+    printf "\n******* ERROR *******\n"
+    printf "\n    A directory with the name '%s' already exists." "$dir_name"
+    printf "\n    Try running again with a different name.\n"
+    printf "\n    Example command with name provided:\n"
+    printf "\n    ./utils.sh new MySuperFunGameName\n"
+    printf "\n*********************\n\n"
+    exit 1
+  fi
+
+  command cp -r ./src/games/miniGameTemplate "$new_dir_path"
+  
+  # Replace "YourMiniGame" in sketch and class
+  # with user provided name
+  local new_sketch_file="$new_dir_path/sketch.js"
+  local new_class_file="$new_dir_path/miniGameClass.js"
+  command sed -i "" "s/YourMiniGame/$class_name/" "$new_sketch_file"
+  command sed -i "" "s/YourMiniGame/$class_name/" "$new_class_file"
+}
+
+
+util_update_templates() {
+  echo "Not implemented yet"
+  exit 1
+}
+
+
+# Check if valid function name passed
+# Run function with remaining args
+if declare -f "util_$1" >/dev/null 2>&1; then
+  func="util_$1"
+  shift
+  "$func" "$@"
+else
+  echo "Function $1 not recognized" >&2
+  exit 1
+fi

--- a/utils.sh
+++ b/utils.sh
@@ -77,8 +77,8 @@ util_new() {
   # with user provided name
   local new_sketch_file="$new_dir_path/sketch.js"
   local new_class_file="$new_dir_path/miniGameClass.js"
-  command sed -i "" "s/YourMiniGame as UserMiniGame/$class_name as UserMiniGame/" "$new_sketch_file"
-  command sed -i "" "s/YourMiniGame/$class_name/" "$new_class_file"
+  command sed -i.bak -e "s/YourMiniGame as UserMiniGame/$class_name as UserMiniGame/" -- "$new_sketch_file" && rm -- "$new_sketch_file.bak"
+  command sed -i.bak -e "s/YourMiniGame/$class_name/" -- "$new_class_file" && rm -- "$new_class_file.bak"
 }
 
 
@@ -88,7 +88,7 @@ util_new() {
 # * Looks for line exporting/declaring a class that extends MiniGame
 # * echos name of class if found
 find_class_name() {
-  local re="^export class ([A-Za-z]+) extends MiniGame \{$"
+  local re="^export class ([A-Za-z]+) extends MiniGame \{"
   while read -r line ; do 
     if [[ "$line" =~ $re ]]; then 
       echo "${BASH_REMATCH[1]}"
@@ -116,7 +116,7 @@ util_update_templates() {
     if [ "$dirSketchFile" != "$templateSketch" ]; then
       class_name="$(find_class_name "$dirClassFile")"
       command cp "$templateSketch" "$dirSketchFile"
-      command sed -i "" "s/YourMiniGame as UserMiniGame/$class_name as UserMiniGame/" "$dirSketchFile"
+      command sed -i.bak -e "s/YourMiniGame as UserMiniGame/$class_name as UserMiniGame/" -- "$dirSketchFile" && rm -- "$dirSketchFile.bak"
     fi
   done
 }


### PR DESCRIPTION
Closes #51 

Didn't commit changes to all sketch files that the `update_templates` util performs.  I tested it, and it seems to work, but I didn't want to end up with any conflicts with #50.  The util makes updating these low effort so we can run and have a sketch update PR after this and #50 are merged.

Tested on my 2 macbooks default bash terminals.... need a windows git bash test run of each function

### Testing:

#### Give the utils file permission to run

```bash
chown +x ./utils.sh
```

#### Test `new` command

Test with default "YourMiniGame" name.  Should create a dir named `yourMiniGame` in `src/games`.

```bash
./utils.sh new
# Running command again should print error message saying dir already exists
```

Test with a custom name. Should create a dir named `yourMiniGame` in `src/games` and replace the import/export in `src/games/<newName>/sketch.js`/`src/games/<newName>/miniGameClass.js` with the given name.

```bash
./utils.sh new dadBall
# Running command again should print error message saying dir already exists
```

#### Test `update_templates` command

Should overwrite all `src/games/*/sketch.js` files with the current `src/games/miniGameTemplate/sketch.js`

```bash
./utils.sh update_templates
```

#### Test invalid command

Should say invalid and show valid options

```bash
./utils.sh wesGat
```